### PR TITLE
updates cartridge to make it OOP-like [clang]

### DIFF
--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -17,11 +17,11 @@ typedef struct
   byte m_nameTableMirroring;
   byte m_mapperNumber;
   bool m_extendedRAM;
+  void (*loadFromFile)(void*);
 } cartridge_t;
 
 cartridge_t* create();
 cartridge_t* destroy(cartridge_t*);
-void loadFromFile(cartridge_t*);
 
 #endif
 

--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -20,8 +20,11 @@ typedef struct
   void (*loadFromFile)(void*);
 } cartridge_t;
 
-cartridge_t* create();
-cartridge_t* destroy(cartridge_t*);
+typedef struct
+{
+  cartridge_t* (*create)();
+  cartridge_t* (*destroy)(cartridge_t*);
+} cartridge_namespace;
 
 #endif
 

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -15,7 +15,7 @@ static void util_copy (size_t size, byte* restrict dst, const byte* restrict src
 }
 
 
-static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads Header of ROM into cartridge
+static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads ROM Header into cartridge
 {
   size_t size = 0x10;
   byte header[size];

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -10,7 +10,7 @@
 
 
 
-void util_copy (size_t size, byte* restrict dst, const byte* restrict src)
+static void util_copy (size_t size, byte* restrict dst, const byte* restrict src)
 {
   for (size_t i = 0; i != size; ++i)
   {
@@ -19,7 +19,7 @@ void util_copy (size_t size, byte* restrict dst, const byte* restrict src)
 }
 
 
-int load_H_ROM (FILE* rom, cartridge_t* c)	// loads Header of ROM into cartridge
+static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads Header of ROM into cartridge
 {
   size_t size = 0x10;
   byte header[size];
@@ -48,7 +48,7 @@ int load_H_ROM (FILE* rom, cartridge_t* c)	// loads Header of ROM into cartridge
 }
 
 
-int load_PRG_ROM (FILE* rom, cartridge_t* c)
+static int load_PRG_ROM (FILE* rom, cartridge_t* c)
 {
   byte* header = c -> header;
   byte banks = header[4];
@@ -99,7 +99,7 @@ int load_PRG_ROM (FILE* rom, cartridge_t* c)
 }
 
 
-int load_CHR_ROM (FILE* rom, cartridge_t* c)
+static int load_CHR_ROM (FILE* rom, cartridge_t* c)
 {
   byte* header = c -> header;
   byte vbanks = header[5];
@@ -147,7 +147,7 @@ int load_CHR_ROM (FILE* rom, cartridge_t* c)
 }
 
 
-void setTableMirroring (cartridge_t* c)
+static void setTableMirroring (cartridge_t* c)
 {
   byte* header = c -> header;
   byte const isFourScreenMirroringBitSet = (header[6] & 0x08);
@@ -186,7 +186,7 @@ void setTableMirroring (cartridge_t* c)
 }
 
 
-void setMapperNumber (cartridge_t* c)
+static void setMapperNumber (cartridge_t* c)
 {
   byte* header = c -> header;
   byte m_mapperNumber = ( ( (header[6] >> 4) & 0x0f ) | (header[7] & 0xf0) );
@@ -195,7 +195,7 @@ void setMapperNumber (cartridge_t* c)
 }
 
 
-void setExtendedRAM (cartridge_t* c)
+static void setExtendedRAM (cartridge_t* c)
 {
   byte* header = c -> header;
   byte const isExtendedRAMBitSet = (header[6] & 0x02);
@@ -205,7 +205,7 @@ void setExtendedRAM (cartridge_t* c)
 }
 
 
-void info_colorSystem (cartridge_t* c)
+static void info_colorSystem (cartridge_t* c)
 {
   byte* header = c -> header;
   byte const isColorSystemBitSet = (header[0x0a] & 0x01);
@@ -224,7 +224,7 @@ void info_colorSystem (cartridge_t* c)
 }
 
 
-int hasTrainerSupport (FILE* rom, cartridge_t* c)
+static int hasTrainerSupport (FILE* rom, cartridge_t* c)
 {
   byte* header = c -> header;
   byte const isTrainerBitSet = (header[6] & 0x04);
@@ -242,8 +242,9 @@ int hasTrainerSupport (FILE* rom, cartridge_t* c)
 }
 
 
-void loadFromFile (cartridge_t* c)
+static void loadFromFile (void* v_cartridge)
 {
+  cartridge_t* c = v_cartridge;
   FILE* rom = fopen("ROM", "rb");
   if (rom == NULL)
   {
@@ -307,6 +308,8 @@ cartridge_t* create ()
   c -> m_nameTableMirroring = 0;
   c -> m_mapperNumber = 0;
   c -> m_extendedRAM = false;
+
+  c -> loadFromFile = loadFromFile;
 
   return c;
 }

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -6,58 +6,8 @@
 #define NES_SUCCESS_STATE ( (int) 0x00000000 )
 
 
-cartridge_t* create ()
-{
-  cartridge_t* c = malloc( sizeof(cartridge_t) );
-  if (c == NULL)
-  {
-    return c;
-  }
-
-  c -> header = NULL;
-  c -> m_PRG_ROM = NULL;
-  c -> m_CHR_ROM = NULL;
-  c -> num_banks = 0;
-  c -> num_vbanks = 0;
-  c -> banks = 0;
-  c -> vbanks = 0;
-  c -> m_nameTableMirroring = 0;
-  c -> m_mapperNumber = 0;
-  c -> m_extendedRAM = false;
-
-  return c;
-}
 
 
-cartridge_t* destroy (cartridge_t* c)
-{
-  if (c == NULL)
-  {
-    return c;
-  }
-
-  if (c -> header != NULL)
-  {
-    free(c -> header);
-    c -> header= NULL;
-  }
-
-  if (c -> m_PRG_ROM != NULL)
-  {
-    free(c -> m_PRG_ROM);
-    c -> m_PRG_ROM = NULL;
-  }
-
-  if (c -> m_CHR_ROM != NULL)
-  {
-    free(c -> m_CHR_ROM);
-    c -> m_CHR_ROM = NULL;
-  }
-
-  free(c);
-  c = NULL;
-  return c;
-}
 
 
 void util_copy (size_t size, byte* restrict dst, const byte* restrict src)
@@ -339,6 +289,58 @@ void loadFromFile (cartridge_t* c)
 }
 
 
+cartridge_t* create ()
+{
+  cartridge_t* c = malloc( sizeof(cartridge_t) );
+  if (c == NULL)
+  {
+    return c;
+  }
+
+  c -> header = NULL;
+  c -> m_PRG_ROM = NULL;
+  c -> m_CHR_ROM = NULL;
+  c -> num_banks = 0;
+  c -> num_vbanks = 0;
+  c -> banks = 0;
+  c -> vbanks = 0;
+  c -> m_nameTableMirroring = 0;
+  c -> m_mapperNumber = 0;
+  c -> m_extendedRAM = false;
+
+  return c;
+}
+
+
+cartridge_t* destroy (cartridge_t* c)
+{
+  if (c == NULL)
+  {
+    return c;
+  }
+
+  if (c -> header != NULL)
+  {
+    free(c -> header);
+    c -> header= NULL;
+  }
+
+  if (c -> m_PRG_ROM != NULL)
+  {
+    free(c -> m_PRG_ROM);
+    c -> m_PRG_ROM = NULL;
+  }
+
+  if (c -> m_CHR_ROM != NULL)
+  {
+    free(c -> m_CHR_ROM);
+    c -> m_CHR_ROM = NULL;
+  }
+
+  free(c);
+  c = NULL;
+  return c;
+}
 // NES Emulation					May 29, 2023
 //
 //			Academic Purpose

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -6,10 +6,6 @@
 #define NES_SUCCESS_STATE ( (int) 0x00000000 )
 
 
-
-
-
-
 static void util_copy (size_t size, byte* restrict dst, const byte* restrict src)
 {
   for (size_t i = 0; i != size; ++i)

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -290,7 +290,7 @@ static void loadFromFile (void* v_cartridge)
 }
 
 
-cartridge_t* create ()
+static cartridge_t* create ()
 {
   cartridge_t* c = malloc( sizeof(cartridge_t) );
   if (c == NULL)
@@ -315,7 +315,7 @@ cartridge_t* create ()
 }
 
 
-cartridge_t* destroy (cartridge_t* c)
+static cartridge_t* destroy (cartridge_t* c)
 {
   if (c == NULL)
   {
@@ -344,6 +344,14 @@ cartridge_t* destroy (cartridge_t* c)
   c = NULL;
   return c;
 }
+
+
+cartridge_namespace const cartridge = {
+  .create = create,
+  .destroy = destroy
+};
+
+
 // NES Emulation					May 29, 2023
 //
 //			Academic Purpose

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@
 int main ()
 {
   cartridge_t* c = create();
-  loadFromFile(c);
+  c -> loadFromFile(c);
 
   if (c -> m_PRG_ROM == NULL)
   {

--- a/src/main.c
+++ b/src/main.c
@@ -22,10 +22,11 @@
 #include <stdio.h>
 #include "cartridge.h"
 
+extern cartridge_namespace const cartridge;
 
 int main ()
 {
-  cartridge_t* c = create();
+  cartridge_t* c = cartridge.create();
   c -> loadFromFile(c);
 
   if (c -> m_PRG_ROM == NULL)
@@ -38,7 +39,7 @@ int main ()
     printf("OK\n");
   }
 
-  c = destroy(c);
+  c = cartridge.destroy(c);
   return 0;
 }
 


### PR DESCRIPTION
Makes the cartridge type similar in spirit to a class in the OOP sense by hiding the implementation methods (those methods which are not meant to be used elsewhere).

Defines a namespace for the cartridge (de)constructors (the utility methods that handle memory). A similar approach shall be used for other (to be emulated) components of the NES.

The code executes as in previous commits, no new functionality has been added.

Valgrind reports no memory problems.