### PR TITLE
hides cartridge data from NES components [clang]

### DIFF
--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -7,16 +7,9 @@
 
 typedef struct
 {
-  byte* header;
-  byte* m_PRG_ROM;
-  byte* m_CHR_ROM;
-  size_t num_banks;
-  size_t num_vbanks;
-  byte banks;
-  byte vbanks;
-  byte m_nameTableMirroring;
-  byte m_mapperNumber;
-  bool m_extendedRAM;
+  // private:
+  void* data;
+  // public:
   void (*loadFromFile)(void*);
 } cartridge_t;
 

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@ int main ()
   cartridge_t* c = cartridge.create();
   c -> loadFromFile(c);
 
+  /*
   if (c -> m_PRG_ROM == NULL)
   {
     printf("PRG-ROM NOT OK\n");
@@ -38,6 +39,7 @@ int main ()
   {
     printf("OK\n");
   }
+  */
 
   c = cartridge.destroy(c);
   return 0;


### PR DESCRIPTION
COMMENTS:
Makes the cartridge data (effectively) private.

This has been achieved by moving type definition of the cartridge data type to the implementation file `cartridge.c'. Since it is not present in the header file `cartridge.h' there is no means for the other NES components to ``know'' the underlying type of the private data to be able to access it.

The code displays the expected output on the console.

Valgrind reports no memory issues.