### PR TITLE
renames byte type [clang]

### DIFF
--- a/inc/byte.h
+++ b/inc/byte.h
@@ -1,7 +1,7 @@
 #ifndef NES_BYTE_TYPE_H
 #define NES_BYTE_TYPE_H
 
-typedef unsigned char byte;
+typedef unsigned char byte_t;
 
 #endif
 

--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -3,7 +3,6 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
-#include "byte.h"
 
 typedef struct
 {

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "cartridge.h"
+#include "byte.h"
 
 
 #define NES_FAILURE_STATE ( (int) 0xffffffff )
@@ -9,20 +10,20 @@
 // cartridge private data typedef:
 typedef struct
 {
-  byte* header;
-  byte* m_PRG_ROM;
-  byte* m_CHR_ROM;
+  byte_t* header;
+  byte_t* m_PRG_ROM;
+  byte_t* m_CHR_ROM;
   size_t num_banks;
   size_t num_vbanks;
-  byte banks;
-  byte vbanks;
-  byte m_nameTableMirroring;
-  byte m_mapperNumber;
+  byte_t banks;
+  byte_t vbanks;
+  byte_t m_nameTableMirroring;
+  byte_t m_mapperNumber;
   bool m_extendedRAM;
 } data_t;
 
 
-static void util_copy (size_t size, byte* restrict dst, const byte* restrict src)
+static void util_copy (size_t size, byte_t* restrict dst, const byte_t* restrict src)
 {
   for (size_t i = 0; i != size; ++i)
   {
@@ -34,8 +35,8 @@ static void util_copy (size_t size, byte* restrict dst, const byte* restrict src
 static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads ROM Header into cartridge
 {
   size_t size = 0x10;
-  byte header[size];
-  size_t count = fread(header, sizeof(byte), size, rom);
+  byte_t header[size];
+  size_t count = fread(header, sizeof(byte_t), size, rom);
   if (count != size)
   {
     printf("Invalid NES ROM\n");
@@ -46,7 +47,7 @@ static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads ROM Header into cartr
   printf("header: %c %c %c %x\n", header[0], header[1], header[2], header[3]);
 
   data_t* d = c -> data;
-  d -> header = (byte*) malloc( size * sizeof(byte) );
+  d -> header = (byte_t*) malloc( size * sizeof(byte_t) );
   if (d -> header == NULL)
   {
     printf("failed to allocate memory for ROM header!\n");
@@ -54,7 +55,7 @@ static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads ROM Header into cartr
     return NES_FAILURE_STATE;
   }
 
-  byte* h = d -> header;
+  byte_t* h = d -> header;
   util_copy(size, h, header);
 
   return NES_SUCCESS_STATE;
@@ -64,8 +65,8 @@ static int load_H_ROM (FILE* rom, cartridge_t* c)	// loads ROM Header into cartr
 static int load_PRG_ROM (FILE* rom, cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte banks = header[4];
+  byte_t* header = d -> header;
+  byte_t banks = header[4];
   printf("16KB PRG-ROM Banks: %u \n", banks);
   if (!banks)
   {
@@ -84,8 +85,8 @@ static int load_PRG_ROM (FILE* rom, cartridge_t* c)
   d -> banks = banks;
 
   size_t num_banks = (0x4000 * banks);
-  byte b_PRG_ROM[num_banks];
-  size_t count = fread(b_PRG_ROM, sizeof(byte), num_banks, rom);
+  byte_t b_PRG_ROM[num_banks];
+  size_t count = fread(b_PRG_ROM, sizeof(byte_t), num_banks, rom);
   if (num_banks != count)
   {
     printf("Failed to read PRG-ROM!\n");
@@ -100,7 +101,7 @@ static int load_PRG_ROM (FILE* rom, cartridge_t* c)
   }
   d -> num_banks = num_banks;
 
-  d -> m_PRG_ROM = (byte*) malloc( num_banks * sizeof(byte) );
+  d -> m_PRG_ROM = (byte_t*) malloc( num_banks * sizeof(byte_t) );
 
   if (d -> m_PRG_ROM == NULL)
   {
@@ -115,7 +116,7 @@ static int load_PRG_ROM (FILE* rom, cartridge_t* c)
     return NES_FAILURE_STATE;
   }
 
-  byte* m_PRG_ROM = d -> m_PRG_ROM;
+  byte_t* m_PRG_ROM = d -> m_PRG_ROM;
   util_copy(num_banks, m_PRG_ROM, b_PRG_ROM);
 
   return NES_SUCCESS_STATE;
@@ -125,16 +126,16 @@ static int load_PRG_ROM (FILE* rom, cartridge_t* c)
 static int load_CHR_ROM (FILE* rom, cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte vbanks = header[5];
+  byte_t* header = d -> header;
+  byte_t vbanks = header[5];
   d -> vbanks = vbanks;
   printf("8KB CHR-ROM Banks: %u \n", vbanks);
 
   if (vbanks)
   {
     size_t num_vbanks = (0x2000 * vbanks);
-    byte b_CHR_ROM[num_vbanks];
-    size_t count = fread(b_CHR_ROM, sizeof(byte), num_vbanks, rom);
+    byte_t b_CHR_ROM[num_vbanks];
+    size_t count = fread(b_CHR_ROM, sizeof(byte_t), num_vbanks, rom);
     if (num_vbanks != count)
     {
       printf("Failed to read CHR-ROM!\n");
@@ -151,7 +152,7 @@ static int load_CHR_ROM (FILE* rom, cartridge_t* c)
     }
     d -> num_vbanks = num_vbanks;
 
-    d -> m_CHR_ROM = (byte*) malloc( num_vbanks * sizeof(byte) );
+    d -> m_CHR_ROM = (byte_t*) malloc( num_vbanks * sizeof(byte_t) );
 
     if (d -> m_CHR_ROM == NULL)
     {
@@ -168,7 +169,7 @@ static int load_CHR_ROM (FILE* rom, cartridge_t* c)
       return NES_FAILURE_STATE;
     }
 
-    byte* m_CHR_ROM = d -> m_CHR_ROM;
+    byte_t* m_CHR_ROM = d -> m_CHR_ROM;
     util_copy(num_vbanks, m_CHR_ROM, b_CHR_ROM);
   }
 
@@ -180,8 +181,8 @@ static int load_CHR_ROM (FILE* rom, cartridge_t* c)
 static void setTableMirroring (cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte const isFourScreenMirroringBitSet = (header[6] & 0x08);
+  byte_t* header = d -> header;
+  byte_t const isFourScreenMirroringBitSet = (header[6] & 0x08);
   if (isFourScreenMirroringBitSet)
   {
     enum nameTableMirroring // from Mapper, placed here temporarily
@@ -192,14 +193,14 @@ static void setTableMirroring (cartridge_t* c)
     };
     enum nameTableMirroring mirroring;
     mirroring = FourScreen;
-    byte m_nameTableMirroring = mirroring;
+    byte_t m_nameTableMirroring = mirroring;
     printf("Name Table Mirroring: %u \n", m_nameTableMirroring);
     d -> m_nameTableMirroring = m_nameTableMirroring;
   }
   else
   {
-    byte const isTableMirroringBitSet = (header[6] & 0x01);
-    byte m_nameTableMirroring = isTableMirroringBitSet;
+    byte_t const isTableMirroringBitSet = (header[6] & 0x01);
+    byte_t m_nameTableMirroring = isTableMirroringBitSet;
     switch (m_nameTableMirroring)
     {
       case 0:
@@ -220,8 +221,8 @@ static void setTableMirroring (cartridge_t* c)
 static void setMapperNumber (cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte m_mapperNumber = ( ( (header[6] >> 4) & 0x0f ) | (header[7] & 0xf0) );
+  byte_t* header = d -> header;
+  byte_t m_mapperNumber = ( ( (header[6] >> 4) & 0x0f ) | (header[7] & 0xf0) );
   d -> m_mapperNumber = m_mapperNumber;
   printf("Mapper Number: %u \n", m_mapperNumber);
 }
@@ -230,8 +231,8 @@ static void setMapperNumber (cartridge_t* c)
 static void setExtendedRAM (cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte const isExtendedRAMBitSet = (header[6] & 0x02);
+  byte_t* header = d -> header;
+  byte_t const isExtendedRAMBitSet = (header[6] & 0x02);
   bool m_extendedRAM = (isExtendedRAMBitSet)? true : false;
   d -> m_extendedRAM = m_extendedRAM;
   printf("Extended CPU RAM: %u \n", m_extendedRAM);
@@ -241,8 +242,8 @@ static void setExtendedRAM (cartridge_t* c)
 static void info_colorSystem (cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte const isColorSystemBitSet = (header[0x0a] & 0x01);
+  byte_t* header = d -> header;
+  byte_t const isColorSystemBitSet = (header[0x0a] & 0x01);
   //if ( (header[0xa] & 0x3) == 0x2 || (header[0xa] & 0x1) ) // what you should test
   if (isColorSystemBitSet)
   {
@@ -261,8 +262,8 @@ static void info_colorSystem (cartridge_t* c)
 static int hasTrainerSupport (FILE* rom, cartridge_t* c)
 {
   data_t* d = c -> data;
-  byte* header = d -> header;
-  byte const isTrainerBitSet = (header[6] & 0x04);
+  byte_t* header = d -> header;
+  byte_t const isTrainerBitSet = (header[6] & 0x04);
   if (isTrainerBitSet)
   {
     printf("Unsupported Trainer!\n");


### PR DESCRIPTION
this has been done to adhere to the (adopted) convention for user-defined types

byte type: `byte_t`
address type: `address_t`
cartridge type: `cartridge_t`
mapper type: `mapper_t`