### PR TITLE
applies naming convention for user-defined types

### DIFF
--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -16,7 +16,7 @@ typedef struct
 {
   cartridge_t* (*create)();
   cartridge_t* (*destroy)(cartridge_t*);
-} cartridge_namespace;
+} cartridge_namespace_t;
 
 #endif
 

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -407,7 +407,7 @@ static cartridge_t* destroy (cartridge_t* c)
 }
 
 
-cartridge_namespace const cartridge = {
+cartridge_namespace_t const cartridge = {
   .create = create,
   .destroy = destroy
 };

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include "cartridge.h"
 
-extern cartridge_namespace const cartridge;
+extern cartridge_namespace_t const cartridge;
 
 int main ()
 {


### PR DESCRIPTION
this has been done to adhere to the (adopted) convention for user-defined types

byte type: `byte_t`
address type: `address_t`
cartridge type: `cartridge_t`
mapper type: `mapper_t`