### PR TITLE
applies style change for readability [clang]

### DIFF
--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -12,14 +12,14 @@ typedef struct
   // private:
   void* data;
   // public:
-  void (*loadFromFile)(void*);
-  byte_t (*getNameTableMirroring)(void*);
+  void (*loadFromFile) (void*);
+  byte_t (*getNameTableMirroring) (void*);
 } cartridge_t;
 
 typedef struct
 {
-  cartridge_t* (*create)();
-  cartridge_t* (*destroy)(cartridge_t*);
+  cartridge_t* (*create) (void);
+  cartridge_t* (*destroy) (cartridge_t*);
 } cartridge_namespace_t;
 
 #endif


### PR DESCRIPTION
mapper (not yet committed) would be harder to read without the space so I am applying this change in cartridge for consistency