### PR TITLE
makes Cartridge::getNameTableMirroring() const

### DIFF
--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -13,7 +13,7 @@ typedef struct
   void* data;
   // public:
   void (*loadFromFile) (void*);
-  byte_t (*getNameTableMirroring) (void*);
+  byte_t (*getNameTableMirroring) (const void*);
 } cartridge_t;
 
 typedef struct

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -321,10 +321,10 @@ static void loadFromFile (void* v_cartridge)
 }
 
 
-static byte_t getNameTableMirroring (void* v_cartridge)
+static byte_t getNameTableMirroring (const void* v_cartridge)
 {
-  cartridge_t* c = v_cartridge;
-  data_t* data = c -> data;
+  const cartridge_t* c = v_cartridge;
+  const data_t* data = c -> data;
   byte_t ntm = data -> m_nameTableMirroring;
   return ntm;
 }


### PR DESCRIPTION
COMMENTS:
grants Cartridge::getNameTableMirroring() read-only access to the private data of cartridge, for a getter should **Not** modify it.