### PR TITLE
implements (core) Mapper::Mapper methods [clang]

### DIFF
--- a/inc/mapper.h
+++ b/inc/mapper.h
@@ -21,13 +21,13 @@ typedef struct	// Mapper
   // protected:
   void* data;
   // public:
-  byte_t (*readPRG) (const address_t);
-  byte_t (*readCHR) (const address_t);
-  void (*writePRG) (const address_t, const byte_t);
-  void (*writeCHR) (const address_t, const byte_t);
+  byte_t (*readPRG) (const void*, const address_t);
+  byte_t (*readCHR) (const void*, const address_t);
+  void (*writePRG) (void*, const address_t, const byte_t);
+  void (*writeCHR) (void*, const address_t, const byte_t);
   nameTableMirroring_t (*getNameTableMirroring) (const void*);
   bool (*hasExtendedRAM) (const void*);
-  void (*scanlineIRQ) (void);
+  void (*scanlineIRQ) (void*);
 } mapper_t;
 
 typedef struct

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,15 @@ int main ()
   mapperKind_t k = NROM;
   mapper_t* map = mapper.create(c, k);
 
+  map -> readPRG(map, 0);
+  map -> readCHR(map, 0);
+  map -> writePRG(map, 0, 0);
+  map -> writeCHR(map, 0, 0);
+  nameTableMirroring_t ntm = map -> getNameTableMirroring(map);
+  printf("Mapper::Mapper: %d name table mirroring: %d\n", k, ntm);
+  printf("Mapper::Mapper: %d has extended RAM: %d\n", k, map -> hasExtendedRAM(map));
+  map -> scanlineIRQ(map);
+
   /*
   if (c -> m_PRG_ROM == NULL)
   {

--- a/src/mapper.c
+++ b/src/mapper.c
@@ -10,6 +10,44 @@ typedef struct
 } data_t;
 
 
+static byte_t readPRG (const void* v_mapper, const address_t addr)
+{
+  const mapper_t* mapper = v_mapper;
+  const data_t* data = mapper -> data;
+  mapperKind_t kind = data -> m_kind;
+  printf("Mapper::Mapper: %d reading PRG address %x ... done\n", kind, addr);
+  return 0;
+}
+
+
+static byte_t readCHR (const void* v_mapper, const address_t addr)
+{
+  const mapper_t* mapper = v_mapper;
+  const data_t* data = mapper -> data;
+  mapperKind_t kind = data -> m_kind;
+  printf("Mapper::Mapper: %d reading CHR address %x ... done\n", kind, addr);
+  return 0;
+}
+
+
+static void writePRG (void* v_mapper, const address_t addr, const byte_t byte)
+{
+  mapper_t* mapper = v_mapper;
+  const data_t* data = mapper -> data;
+  mapperKind_t kind = data -> m_kind;
+  printf("Mapper::Mapper: %d writing %x PRG address %x ... done\n", kind, byte, addr);
+}
+
+
+static void writeCHR (void* v_mapper, const address_t addr, const byte_t byte)
+{
+  mapper_t* mapper = v_mapper;
+  const data_t* data = mapper -> data;
+  mapperKind_t kind = data -> m_kind;
+  printf("Mapper::Mapper: %d writing %x CHR address %x ... done\n", kind, byte, addr);
+}
+
+
 static nameTableMirroring_t getNameTableMirroring (const void* v_mapper)
 {
   const mapper_t* mapper = v_mapper;
@@ -27,6 +65,15 @@ static bool hasExtendedRAM (const void* v_mapper)
   const cartridge_t* m_cartridge = data -> m_cartridge;
   bool ret = m_cartridge -> hasExtendedRAM(m_cartridge);
   return ret;
+}
+
+
+static void scanlineIRQ (void* v_mapper)
+{
+  mapper_t* mapper = v_mapper;
+  const data_t* data = mapper -> data;
+  mapperKind_t kind = data -> m_kind;
+  printf("Mapper::Mapper: %d Mapper::scalineIRQ\n", kind);
 }
 
 
@@ -51,13 +98,13 @@ static mapper_t* create (cartridge_t* cart, const mapperKind_t kind)
   data -> m_cartridge = cart;
   data -> m_kind = kind;
 
-  mapper -> readPRG = NULL;
-  mapper -> readCHR = NULL;
-  mapper -> writePRG = NULL;
-  mapper -> writeCHR = NULL;
+  mapper -> readPRG = readPRG;
+  mapper -> readCHR = readCHR;
+  mapper -> writePRG = writePRG;
+  mapper -> writeCHR = writeCHR;
   mapper -> getNameTableMirroring = getNameTableMirroring;
   mapper -> hasExtendedRAM = hasExtendedRAM;
-  mapper -> scanlineIRQ = NULL;
+  mapper -> scanlineIRQ = scanlineIRQ;
 
   return mapper;
 }


### PR DESCRIPTION
the methods shall be overridden by the mappers derived from the core (or base) mapper 