### PR TITLE
adds Cartridge::getROM() and Cartridge::getVROM() [clang]

### DIFF
--- a/inc/cartridge.h
+++ b/inc/cartridge.h
@@ -13,6 +13,10 @@ typedef struct
   void* data;
   // public:
   void (*loadFromFile) (void*);
+  byte_t* (*getROM) (const void*);
+  byte_t* (*getVROM) (const void*);
+  size_t (*getSizeROM) (const void*);
+  size_t (*getSizeVROM) (const void*);
   byte_t (*getNameTableMirroring) (const void*);
   bool (*hasExtendedRAM) (const void*);
 } cartridge_t;

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -130,47 +130,51 @@ static int load_CHR_ROM (FILE* rom, cartridge_t* c)
   d -> vbanks = vbanks;
   printf("8KB CHR-ROM Banks: %u \n", vbanks);
 
-  if (vbanks)
+  if (vbanks == 0)
   {
-    size_t num_vbanks = (0x2000 * vbanks);
-    byte_t b_CHR_ROM[num_vbanks];
-    size_t count = fread(b_CHR_ROM, sizeof(byte_t), num_vbanks, rom);
-    if (num_vbanks != count)
-    {
-      printf("Failed to read CHR-ROM!\n");
-      free(d -> header);
-      d -> header = NULL;
-      header = NULL;
-      free(d -> m_PRG_ROM);
-      d -> m_PRG_ROM = NULL;
-      free(c -> data);
-      c -> data = NULL;
-      d = NULL;
-      fclose(rom);
-      return NES_FAILURE_STATE;
-    }
-    d -> num_vbanks = num_vbanks;
-
-    d -> m_CHR_ROM = (byte_t*) malloc( num_vbanks * sizeof(byte_t) );
-
-    if (d -> m_CHR_ROM == NULL)
-    {
-      printf("failed to allocate memory for CHR-ROM!\n");
-      free(d -> header);
-      d -> header = NULL;
-      header = NULL;
-      free(d -> m_PRG_ROM);
-      d -> m_PRG_ROM = NULL;
-      free(c -> data);
-      c -> data = NULL;
-      d = NULL;
-      fclose(rom);
-      return NES_FAILURE_STATE;
-    }
-
-    byte_t* m_CHR_ROM = d -> m_CHR_ROM;
-    util_copy(num_vbanks, m_CHR_ROM, b_CHR_ROM);
+    d -> num_vbanks = 0;
+    d -> m_CHR_ROM = NULL;
+    return NES_SUCCESS_STATE;
   }
+
+  size_t num_vbanks = (0x2000 * vbanks);
+  byte_t b_CHR_ROM[num_vbanks];
+  size_t count = fread(b_CHR_ROM, sizeof(byte_t), num_vbanks, rom);
+  if (num_vbanks != count)
+  {
+    printf("Failed to read CHR-ROM!\n");
+    free(d -> header);
+    d -> header = NULL;
+    header = NULL;
+    free(d -> m_PRG_ROM);
+    d -> m_PRG_ROM = NULL;
+    free(c -> data);
+    c -> data = NULL;
+    d = NULL;
+    fclose(rom);
+    return NES_FAILURE_STATE;
+  }
+  d -> num_vbanks = num_vbanks;
+
+  d -> m_CHR_ROM = (byte_t*) malloc( num_vbanks * sizeof(byte_t) );
+
+  if (d -> m_CHR_ROM == NULL)
+  {
+    printf("failed to allocate memory for CHR-ROM!\n");
+    free(d -> header);
+    d -> header = NULL;
+    header = NULL;
+    free(d -> m_PRG_ROM);
+    d -> m_PRG_ROM = NULL;
+    free(c -> data);
+    c -> data = NULL;
+    d = NULL;
+    fclose(rom);
+    return NES_FAILURE_STATE;
+  }
+
+  byte_t* m_CHR_ROM = d -> m_CHR_ROM;
+  util_copy(num_vbanks, m_CHR_ROM, b_CHR_ROM);
 
   printf("ROM with CHR-RAM\n");
   return NES_SUCCESS_STATE;

--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -325,6 +325,42 @@ static void loadFromFile (void* v_cartridge)
 }
 
 
+static size_t getSizeROM (const void* v_cartridge)
+{
+  const cartridge_t* c = v_cartridge;
+  const data_t* data = c -> data;
+  size_t size = data -> num_banks;
+  return size;
+}
+
+
+static size_t getSizeVROM (const void* v_cartridge)
+{
+  const cartridge_t* c = v_cartridge;
+  const data_t* data = c -> data;
+  size_t size = data -> num_vbanks;
+  return size;
+}
+
+
+static byte_t* getROM (const void* v_cartridge)
+{
+  const cartridge_t* c = v_cartridge;
+  const data_t* data = c -> data;
+  byte_t* m_PRG_ROM = data -> m_PRG_ROM;
+  return m_PRG_ROM;
+}
+
+
+static byte_t* getVROM (const void* v_cartridge)
+{
+  const cartridge_t* c = v_cartridge;
+  const data_t* data = c -> data;
+  byte_t* m_CHR_ROM = data -> m_CHR_ROM;
+  return m_CHR_ROM;
+}
+
+
 static byte_t getNameTableMirroring (const void* v_cartridge)
 {
   const cartridge_t* c = v_cartridge;
@@ -373,6 +409,10 @@ static cartridge_t* create ()
   d -> m_extendedRAM = false;
 
   c -> loadFromFile = loadFromFile;
+  c -> getROM = getROM;
+  c -> getVROM = getVROM;
+  c -> getSizeROM = getSizeROM;
+  c -> getSizeVROM = getSizeVROM;
   c -> getNameTableMirroring = getNameTableMirroring;
   c -> hasExtendedRAM = hasExtendedRAM;
 

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,9 @@
 #include "cartridge.h"
 #include "mapper.h"
 
+#define SUCCESS ( (int) 0x00000000 )
+#define FAILURE ( (int) 0xffffffff )
+
 extern cartridge_namespace_t const cartridge;
 extern mapper_namespace_t const mapper;
 
@@ -30,6 +33,23 @@ int main ()
 {
   cartridge_t* c = cartridge.create();
   c -> loadFromFile(c);
+
+  if (c == NULL)
+  {
+    return FAILURE;
+  }
+
+  printf("ROM size: %lu \n", c -> getSizeROM(c));
+  if (c -> getROM(c) == NULL)
+  {
+    printf("PRG-ROM NOT OK\n");
+  }
+
+  printf("VROM size: %lu \n", c -> getSizeVROM(c));
+  if (c -> getVROM(c) == NULL)
+  {
+    printf("OK\n");
+  }
 
   mapperKind_t k = NROM;
   mapper_t* map = mapper.create(c, k);
@@ -43,21 +63,9 @@ int main ()
   printf("Mapper::Mapper: %d has extended RAM: %d\n", k, map -> hasExtendedRAM(map));
   map -> scanlineIRQ(map);
 
-  /*
-  if (c -> m_PRG_ROM == NULL)
-  {
-    printf("PRG-ROM NOT OK\n");
-  }
-
-  if (c -> m_CHR_ROM == NULL)
-  {
-    printf("OK\n");
-  }
-  */
-
   map = mapper.destroy(map);
   c = cartridge.destroy(c);
-  return 0;
+  return SUCCESS;
 }
 
 


### PR DESCRIPTION
needed by mappers

emulator produces the expected output

valgrind reports no memory issues