### PR TITLE
minor changes Mapper::AxROM [clang]

### DIFF
--- a/src/mapperAxROM.c
+++ b/src/mapperAxROM.c
@@ -36,7 +36,7 @@ static byte_t readPRG (const void* v_core, const address_t addr)
   const mapperAxROM_t* map = data -> next;
   const byte_t* PRG = cart -> getROM(cart);
   const uint32_t bank_PRG = map -> m_bank_PRG;
-  // NOTE: mixed type arithmetic, address is uint16_t and bank-PRG is uint32_t
+  // NOTE: mixed type arithmetic (from snes), address is uint16_t and bank-PRG is uint32_t
   const uint32_t idx = ( (bank_PRG * 0x8000) + (addr & 0x7fff) );
   const byte_t byte = PRG[idx];
   printf("Mapper::Mapper: %d read %u from PRG at address 0x%x\n", kind, byte, idx);

--- a/src/mapperAxROM.c
+++ b/src/mapperAxROM.c
@@ -172,7 +172,7 @@ static mapper_t* create (cartridge_t* cart, void (*mirroring_cb) (void))
     map -> m_characterRAM = (byte_t*) malloc( size_characterRAM * sizeof(byte_t) );
     for (size_t i = 0; i != size_characterRAM; ++i)
     {
-      map -> m_characterRAM[i] = 0x00;
+      map -> m_characterRAM[i] = ( (byte_t) 0x00 );
     }
     printf("Uses Character RAM OK\n");
   }


### PR DESCRIPTION
updates comment on mixed type arithmetic detected in original source SNES and casts Character RAM elements to byte type (unsigned char).