### PR TITLE
adds diagnostic message Mapper::AxROM:readCHR()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,7 @@ int main ()
   map -> writeCHR(map, 0x1000, 0xff);
   map -> readPRG(map, 0x0000);
   map -> readCHR(map, 0x1000);
+  map -> readCHR(map, 0x4000);	// attempts to read Character RAM at invalid address
   data_t* data = map -> data;
   mapperKind_t k = data -> m_kind;
   nameTableMirroring_t ntm = map -> getNameTableMirroring(map);

--- a/src/mapperAxROM.c
+++ b/src/mapperAxROM.c
@@ -59,14 +59,17 @@ static byte_t readCHR (const void* v_core, const address_t addr)
   }
 
   size_t const size_characterRAM = map -> m_size_characterRAM;
-  if (addr < size_characterRAM)
+  if (addr >= size_characterRAM)
   {
-    byte_t const byte = CHR[addr];
-    printf("Mapper::Mapper: %d read %u CHR at address 0x%x\n", kind, byte, addr);
-    return byte;
+    const char log [] = "Mapper::Mapper: %d attempted to read CHR "
+			"at invalid address 0x%x\n";
+    printf(log, kind, addr);
+    return 0;
   }
 
-  return 0;
+  byte_t const byte = CHR[addr];
+  printf("Mapper::Mapper: %d read %u CHR at address 0x%x\n", kind, byte, addr);
+  return byte;
 }
 
 


### PR DESCRIPTION
COMMENTS:
I would like to know if the AxROM attempts to read the Character-RAM CHR at an invalid address.