### PR TITLE
binds cpu base (or device) component [clang]

### DIFF
--- a/inc/cpu.h
+++ b/inc/cpu.h
@@ -10,14 +10,14 @@ typedef struct	// CPU
 {
   // public:
   bus_t* bus;							// Main Bus
-  device_t* device;						// base type of CPU
+  device_t* dev;						// base type of CPU
   byte_t (*read) (const void*, const address_t);
   void (*write) (void*, const address_t, const byte_t);
 } cpu_t;
 
 typedef struct
 {
-  cpu_t* (*create) (device_t*);
+  cpu_t* (*create) (const device_t*);
   cpu_t* (*destroy) (cpu_t*);
 } cpu_namespace_t;
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -28,7 +28,7 @@ static void ConnectBus (cpu_t* cpu, const device_t* devCPU)
 }
 
 
-static cpu_t* create (device_t* devCPU)
+static cpu_t* create (const device_t* dev)
 {
   cpu_t* cpu = malloc( sizeof(cpu_t) );
   if (cpu == NULL)
@@ -39,8 +39,9 @@ static cpu_t* create (device_t* devCPU)
 
   cpu -> read = read;
   cpu -> write = write;
+  cpu -> dev = dev;
 
-  ConnectBus(cpu, devCPU);
+  ConnectBus(cpu, dev);
 
   return cpu;
 }


### PR DESCRIPTION
COMMENTS:
This was the original intention, to bind the base cpu component (device) to the CPU.

The CPU might not have to modify the base component (read-only) so the `const' qualifier; at least at this point in development.