### PR TITLE
adds cpu addressing modes [clang]

### DIFF
--- a/inc/cpu.h
+++ b/inc/cpu.h
@@ -9,10 +9,32 @@
 typedef struct	// CPU
 {
   // public:
-  bus_t* bus;							// Main Bus
-  const device_t* dev;						// base type of CPU
+  bus_t* bus;						// Main Bus
+  const device_t* dev;					// CPU base type (for Bus Connect)
+  // Registers:
+  address_t pc;						// Program Counter PC
+  address_t abs;					// Absolute Address
+  address_t rel;					// Relative Address
+  byte_t a;						// Accumulator Register
+  byte_t x;						// X Register
+  byte_t y;						// Y Register
+  byte_t fetched;
+  // Bus Connectivity:
   byte_t (*read) (const void*, const address_t);
   void (*write) (void*, const address_t, const byte_t);
+  // Addressing Modes:
+  byte_t (*IMP) (void*);				// Implied
+  byte_t (*IMM) (void*);				// Immediate
+  byte_t (*ZP0) (void*);				// Zero Page
+  byte_t (*ZPX) (void*);				// Zero Page + X Register offset
+  byte_t (*ZPY) (void*);				// Zero Page + Y Register offset
+  byte_t (*ABS) (void*);				// Absolute
+  byte_t (*ABX) (void*);				// Absolute  + X Register offset
+  byte_t (*ABY) (void*);				// Absolute  + Y Register offset
+  byte_t (*IND) (void*);				// Indirect
+  byte_t (*INX) (void*);				// Indirect  + X Register offset
+  byte_t (*INY) (void*);				// Indirect  + Y Register offset
+  byte_t (*REL) (void*);				// Relative
 } cpu_t;
 
 typedef struct

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -28,6 +28,244 @@ static void ConnectBus (cpu_t* cpu, const device_t* devCPU)
 }
 
 
+static byte_t implied (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  byte_t fetched = cpu -> fetched;
+  byte_t const accumulator = cpu -> a;
+
+  fetched = accumulator;
+  cpu -> fetched = fetched;
+  return 0x00;
+}
+
+
+static byte_t immediate (void *vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t pc = cpu -> pc;
+
+  address_t const abs = pc;
+  ++pc;
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t zeroPage (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t pc = cpu -> pc;
+
+  address_t abs = cpu -> read(cpu, pc);
+  ++pc;
+
+  abs &= 0x00ff;
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t zeroPageXRegisterOffset (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t const x = cpu -> x;
+  address_t pc = cpu -> pc;
+
+  address_t abs = cpu -> read(cpu, pc);
+  ++pc;
+
+  abs += x;
+  abs &= 0x00ff;
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t zeroPageYRegisterOffset (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t const y = cpu -> y;
+  address_t pc = cpu -> pc;
+
+  address_t abs = cpu -> read(cpu, pc);
+  ++pc;
+
+  abs += y;
+  abs &= 0x00ff;
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t absolute (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t pc = cpu -> pc;
+
+  address_t const lo = cpu -> read(cpu, pc);
+  ++pc;
+  address_t const hi = cpu -> read(cpu, pc);
+  ++pc;
+
+  address_t const abs = ( (hi << 8) | lo );
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t absoluteXRegisterOffset (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t const x = cpu -> x;
+  address_t pc = cpu -> pc;
+
+  address_t const lo = cpu -> read(cpu, pc);
+  ++pc;
+  address_t const hi = cpu -> read(cpu, pc);
+  ++pc;
+
+  address_t abs = ( (hi << 8) | lo );
+  abs += x;
+
+  bool const inNextPage = ( (abs & 0xff00) != (hi << 8) );
+  byte_t const ret = (inNextPage)? 1 : 0;
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return ret;
+}
+
+
+static byte_t absoluteYRegisterOffset (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t const y = cpu -> y;
+  address_t pc = cpu -> pc;
+
+  address_t const lo = cpu -> read(cpu, pc);
+  ++pc;
+  address_t const hi = cpu -> read(cpu, pc);
+  ++pc;
+
+  address_t abs = ( (hi << 8) | lo );
+  abs += y;
+
+  bool const inNextPage = ( (abs & 0xff00) != (hi << 8) );
+  byte_t const ret = (inNextPage)? 1 : 0;
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return ret;
+}
+
+
+static byte_t indirect (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t abs = cpu -> abs;
+  address_t pc = cpu -> pc;
+
+  address_t const lo = cpu -> read(cpu, pc);
+  ++pc;
+  address_t const hi = cpu -> read(cpu, pc);
+  ++pc;
+
+  address_t const addr = ( (hi << 8) | lo );
+
+  // caters hardware bug
+  if (lo == 0x00ff)
+  {
+    address_t const lo = cpu -> read(cpu, addr);
+    address_t const hi = cpu -> read(cpu, addr & 0xff00);
+    abs = ( (hi << 8) | lo );
+  }
+  else
+  {
+    address_t const lo = cpu -> read(cpu, addr);
+    address_t const hi = cpu -> read(cpu, addr + 1);
+    abs = ( (hi << 8) | lo );
+  }
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t indirectXRegisterOffset (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t const x = cpu -> x;
+  address_t pc = cpu -> pc;
+
+  address_t const addr = cpu -> read(cpu, pc);
+  ++pc;
+
+  address_t const lo = cpu -> read(cpu, (addr + x) & 0x00ff);
+  address_t const hi = cpu -> read(cpu, (addr + x + 1) & 0x00ff);
+
+  address_t const abs = ( (hi << 8) | lo );
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
+static byte_t indirectYRegisterOffset (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t const y = cpu -> y;
+  address_t pc = cpu -> pc;
+
+  address_t const addr = cpu -> read(cpu, pc);
+  ++pc;
+
+  address_t const lo = cpu -> read(cpu, addr & 0x00ff);
+  address_t const hi = cpu -> read(cpu, (addr + 1) & 0x00ff);
+
+  address_t abs = ( (hi << 8) | lo );
+  abs += y;
+
+  bool const inNextPage = ( (abs & 0xff00) != (hi << 8) );
+  byte_t const ret = (inNextPage)? 1 : 0;
+
+  cpu -> abs = abs;
+  cpu -> pc = pc;
+  return ret;
+}
+
+
+
+static byte_t relative (void* vcpu)
+{
+  cpu_t* cpu = vcpu;
+  address_t pc = cpu -> pc;
+
+  address_t rel = cpu -> read(cpu, pc);
+  ++pc;
+
+  if (rel & 0x0080)
+  {
+    rel |= 0xff00;
+  }
+
+  cpu -> rel = rel;
+  cpu -> pc = pc;
+  return 0x00;
+}
+
+
 static cpu_t* create (const device_t* dev)
 {
   cpu_t* cpu = malloc( sizeof(cpu_t) );
@@ -37,9 +275,34 @@ static cpu_t* create (const device_t* dev)
     return cpu;
   }
 
+  // bus connectivity:
   cpu -> read = read;
   cpu -> write = write;
   cpu -> dev = dev;
+
+  // registers:
+  cpu -> pc = 0x0000;
+  cpu -> abs = 0x0000;
+  cpu -> rel = 0x0000;
+  cpu -> a = 0x00;
+  cpu -> x = 0x00;
+  cpu -> y = 0x00;
+
+  cpu -> fetched = 0x00;
+
+  // addressing modes:
+  cpu -> IMP = implied;
+  cpu -> IMM = immediate;
+  cpu -> ZP0 = zeroPage;
+  cpu -> ZPX = zeroPageXRegisterOffset;
+  cpu -> ZPY = zeroPageYRegisterOffset;
+  cpu -> ABS = absolute;
+  cpu -> ABX = absoluteXRegisterOffset;
+  cpu -> ABY = absoluteYRegisterOffset;
+  cpu -> IND = indirect;
+  cpu -> INX = indirectXRegisterOffset;
+  cpu -> INY = indirectYRegisterOffset;
+  cpu -> REL = relative;
 
   ConnectBus(cpu, dev);
 


### PR DESCRIPTION
COMMENTS:
adds initial implementation of the cpu addressing modes

This commit has been inspired by Part 2 of One Lone Coder's Nes Emulator Video:

	https://www.youtube.com/watch?v=8XmxKPJDGU0

valgrind reports no memory issues

note that the cpu emulation is incomplete and that is why it has yet to be tested